### PR TITLE
Find clang library instead of hardcoded path

### DIFF
--- a/cxx2rs.py
+++ b/cxx2rs.py
@@ -4,7 +4,9 @@
 
 import sys
 import clang.cindex
-clang.cindex.Config.set_library_file('/usr/lib/x86_64-linux-gnu/libclang-3.5.so.1')
+
+from ctypes.util import find_library
+clang.cindex.Config.set_library_file(find_library('clang'))
 
 from rustify import *
 from stringify import *

--- a/parser.py
+++ b/parser.py
@@ -1,5 +1,6 @@
 import clang.cindex
-clang.cindex.Config.set_library_file('/usr/lib/x86_64-linux-gnu/libclang-3.5.so.1')
+from ctypes.util import find_library
+clang.cindex.Config.set_library_file(find_library('clang'))
 
 import os.path
 


### PR DESCRIPTION
I was having trouble when trying to use this on Arch with the provided `clang` package.

This fixes it for my case.